### PR TITLE
Exposed static registration methods for custom properties, sets, and …

### DIFF
--- a/Stylish/JSONStylesheet.swift
+++ b/Stylish/JSONStylesheet.swift
@@ -14,15 +14,24 @@ import Foundation
 
 public extension Stylish {
     
-    /// An override point that allows an app using Stylish to specify its own JSONStyleProperty definitions to use when parsing JSON.  A JSONStyleProperty simply defines a way to identify an parse different native Swift values from JSON values, for example, parsing UIEdgeInsets from a JSON dictionary.
-    public static var customJSONStyleProperties: [JSONStyleProperty] = []
+    private static var customJSONStyleProperties: [JSONStyleProperty] = []
     
+    /// A method that allows an app using Stylish to register its own JSONStyleProperty definitions to use when parsing JSON.  A JSONStyleProperty simply defines a way to identify an parse different native Swift values from JSON values, for example, parsing UIEdgeInsets from a JSON dictionary.
+    public static func registerCustomJSONStyleProperties(_ jsonStyleProperties: [JSONStyleProperty]) {
+        let nonDuplicates = jsonStyleProperties.filter{ jsonStyleProperty in customJSONStyleProperties.first{ $0.propertyTypeNames == jsonStyleProperty.propertyTypeNames } == nil }
+            customJSONStyleProperties += nonDuplicates
+    }
     
     /// All defined JSONStyleProperty instances being used by Stylish, which included all the built-in properties plus any specified in customJSONStyleProperties.
     public static var jsonStyleProperties: [JSONStyleProperty] { return customJSONStyleProperties + builtInJSONStyleProperties }
     
-    /// An override point that allows an app using Stylish to specify dynamic style property sets (groups of properties for styling custom components) that can be defined in and parsed from JSON.
-    public static var customDynamicPropertySets: [StylePropertySet.Type] = []
+    private static var customDynamicPropertySets: [StylePropertySet.Type] = []
+    
+    /// A method that allows an app using Stylish to register specific dynamic style property sets (groups of properties for styling custom components) that can be defined in and parsed from JSON.
+    public static func registerCustomDynamicPropertySets(_ dynamicPropertySets: [StylePropertySet.Type]) {
+        let nonDuplicates = dynamicPropertySets.filter{ dynamicPropertySetType in !customDynamicPropertySets.contains{ $0 == dynamicPropertySetType } }
+        customDynamicPropertySets += nonDuplicates
+    }
     
     /// All defined dynamic style property sets being used by Stylish, which included all the built-in property sets plus any specified in customDynamicPropertySets.
     public static var dynamicPropertySets:[StylePropertySet.Type] {

--- a/Stylish/Stylish.swift
+++ b/Stylish/Stylish.swift
@@ -28,8 +28,13 @@ public struct Stylish {
         }
     }
     
-    /// Style classes that should be added to ALL stylesheets. This is useful for common styles that should always remain the same and be available, regardless of which stylesheet is currently applied in the app
-    public static var sharedStyleClasses: [(identifier: String, styleClass: StyleClass)] = []
+    internal static var sharedStyleClasses: [(identifier: String, styleClass: StyleClass)] = []
+    
+    /// A method that allows client apps to register style classes that should be added to ALL stylesheets. This is useful for common styles that should always remain the same and be available, regardless of which stylesheet is currently applied in the app
+    public static func registerSharedStyleClasses(_ styleClasses:[(identifier: String, styleClass: StyleClass)]) {
+        let nonDuplicates = styleClasses.filter{ styleClass in !sharedStyleClasses.contains{ $0.identifier == styleClass.identifier }}
+        sharedStyleClasses += nonDuplicates
+    }
     
     /// Refreshes the styles of all views in the app, in the event of a stylesheet =change or update, etc.
     public static func refreshAllStyles() {

--- a/StylishExample/StylishExample/AppDelegate.swift
+++ b/StylishExample/StylishExample/AppDelegate.swift
@@ -13,9 +13,9 @@ extension UIView {
     // This is the only entry point for setting global variables in Stylish for Interface Builder rendering (since App Delegate doesn't get run by IBDesignable. So we are setting up the same global variable here so they are also available during live previews on Storyboards
     open override func prepareForInterfaceBuilder() {
         // Set our custom property sets that should be part of JSON parsing
-        Stylish.customDynamicPropertySets = [ProgressBarPropertySet.self]
+        Stylish.registerCustomDynamicPropertySets([ProgressBarPropertySet.self])
         // Set the style classes we want to be part of every stylesheet
-        Stylish.sharedStyleClasses = [("Rounded", RoundedStyle()), ("HighlightedText", HighlightedTextStyle())]
+        Stylish.registerSharedStyleClasses([("Rounded", RoundedStyle()), ("HighlightedText", HighlightedTextStyle())])
     }
 }
 
@@ -28,11 +28,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         
         // Set our custom property sets that should be part of JSON parsing
-        Stylish.customDynamicPropertySets = [ProgressBarPropertySet.self]
-        
+        Stylish.registerCustomDynamicPropertySets([ProgressBarPropertySet.self])
+
         // Set the style classes we want to be part of every stylesheet
-        Stylish.sharedStyleClasses = [("Rounded", RoundedStyle()), ("HighlightedText", HighlightedTextStyle())]
-        
+        Stylish.registerSharedStyleClasses([("Rounded", RoundedStyle()), ("HighlightedText", HighlightedTextStyle())])
+
         //Remove the following code if you want to dynamically download and cache a stylesheet from the web.
         let paths = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)
         let documentsDirectory = paths[0]

--- a/StylishExample/StylishExample/Aqua.swift
+++ b/StylishExample/StylishExample/Aqua.swift
@@ -40,7 +40,7 @@ class Aqua : Stylesheet {
 // 3. Inside the init() for your Stylesheet, initialize the styleClasses array with all the StyleClass instances that should be part of this Stylesheet. StyleClasses specific to this Stylesheet can be declared as nested types as you see further down.  Style Classes can also be reused between multiple Stylesheets, for example, the 'RoundedStyle' StyleClass below, which is declared in SharedStyleClasses.swift because it is identical across all Stylesheets.
     
     required init() {
-        styleClasses = [("Rounded", RoundedStyle()), ("HighlightedText", HighlightedTextStyle()),("Primary Background Color", PrimaryBackgroundColor()), ("Secondary Background Color", SecondaryBackgroundColor()), ("Header Text", HeaderText()), ("Body Text", BodyText()), ("Progress Bar", ProgressBar()), ("Default Button", DefaultButton()), ("Stylesheet Title", StylesheetTitle()), ("Theme Image", ThemeImage()), ("Theme Description", ThemeDescription())]
+        styleClasses = [("Primary Background Color", PrimaryBackgroundColor()), ("Secondary Background Color", SecondaryBackgroundColor()), ("Header Text", HeaderText()), ("Body Text", BodyText()), ("Progress Bar", ProgressBar()), ("Default Button", DefaultButton()), ("Stylesheet Title", StylesheetTitle()), ("Theme Image", ThemeImage()), ("Theme Description", ThemeDescription())]
     }
     
 // 4. Here are the specific, nested StyleClass types defined for this Stylesheet. They can be made private, or left internal as below, to allow other Stylesheets to resuse them with their full type identifiers, e.g. 'Aqua.PrimaryBackgroundColor'

--- a/StylishExample/StylishExample/Graphite.swift
+++ b/StylishExample/StylishExample/Graphite.swift
@@ -41,7 +41,7 @@ class Graphite : Stylesheet {
 // 3. Inside the init() for your Stylesheet, initialize the styleClasses array with all the StyleClass instances that should be part of this Stylesheet. StyleClasses specific to this Stylesheet can be declared as nested types as you see further down.  Style Classes can also be reused between multiple Stylesheets, for example, the 'RoundedStyle' StyleClass below, which is declared in SharedStyleClasses.swift because it is identical across all Stylesheets.
     
     required init() {
-        styleClasses = [("Rounded", RoundedStyle()), ("HighlightedText", HighlightedTextStyle()),("Primary Background Color", PrimaryBackgroundColor()), ("Secondary Background Color", SecondaryBackgroundColor()), ("Header Text", HeaderText()), ("Body Text", BodyText()), ("Progress Bar", ProgressBar()), ("Default Button", DefaultButton()), ("Stylesheet Title", StylesheetTitle()), ("Theme Image", ThemeImage()), ("Theme Description", ThemeDescription())]
+        styleClasses = [("Primary Background Color", PrimaryBackgroundColor()), ("Secondary Background Color", SecondaryBackgroundColor()), ("Header Text", HeaderText()), ("Body Text", BodyText()), ("Progress Bar", ProgressBar()), ("Default Button", DefaultButton()), ("Stylesheet Title", StylesheetTitle()), ("Theme Image", ThemeImage()), ("Theme Description", ThemeDescription())]
     }
 
 // 4. Here are the specific, nested StyleClass types defined for this Stylesheet. They can be made private, or left internal as below, to allow other Stylesheets to resuse them with their full type identifiers, e.g. 'Graphite.PrimaryBackgroundColor'


### PR DESCRIPTION
…classes instead of exposing the static vars directly.

This is to prevent multiple clients of Stylish in the same final application from overwriting each other’s custom settings