### PR TITLE
Added support for Constant values that can be reused in the stylesheet

### DIFF
--- a/Stylish.xcodeproj/project.pbxproj
+++ b/Stylish.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		CEC4B3931FB180AE00A97AB5 /* Stylish.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC4B38D1FB180AE00A97AB5 /* Stylish.swift */; };
 		CEC4B3941FB180AE00A97AB5 /* StylesheetParseableExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC4B38E1FB180AE00A97AB5 /* StylesheetParseableExtensions.swift */; };
 		D7C473021F3E4F8A00B5880A /* Stylish.h in Headers */ = {isa = PBXBuildFile; fileRef = D7C473001F3E4F8A00B5880A /* Stylish.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FD8888BA227CAABD00749F18 /* StyleableComponents.swift in Headers */ = {isa = PBXBuildFile; fileRef = CEC4B3891FB180AE00A97AB5 /* StyleableComponents.swift */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -78,6 +79,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D7C473021F3E4F8A00B5880A /* Stylish.h in Headers */,
+				FD8888BA227CAABD00749F18 /* StyleableComponents.swift in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Stylish.xcodeproj/project.pbxproj
+++ b/Stylish.xcodeproj/project.pbxproj
@@ -108,21 +108,22 @@
 		D7C472F41F3E4F8A00B5880A /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1000;
+				LastUpgradeCheck = 1020;
 				TargetAttributes = {
 					D7C472FC1F3E4F8A00B5880A = {
 						CreatedOnToolsVersion = 8.2.1;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Manual;
 					};
 				};
 			};
 			buildConfigurationList = D7C472F71F3E4F8A00B5880A /* Build configuration list for PBXProject "Stylish" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = D7C472F31F3E4F8A00B5880A;
 			productRefGroup = D7C472FE1F3E4F8A00B5880A /* Products */;
@@ -165,6 +166,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -227,6 +229,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -297,7 +300,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -319,7 +322,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = io.danielhall.Stylish;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/Stylish.xcodeproj/xcshareddata/xcschemes/Stylish.xcscheme
+++ b/Stylish.xcodeproj/xcshareddata/xcschemes/Stylish.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1020"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D7C472FC1F3E4F8A00B5880A"
+               BuildableName = "Stylish.framework"
+               BlueprintName = "Stylish"
+               ReferencedContainer = "container:Stylish.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D7C472FC1F3E4F8A00B5880A"
+            BuildableName = "Stylish.framework"
+            BlueprintName = "Stylish"
+            ReferencedContainer = "container:Stylish.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D7C472FC1F3E4F8A00B5880A"
+            BuildableName = "Stylish.framework"
+            BlueprintName = "Stylish"
+            ReferencedContainer = "container:Stylish.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Stylish/PropertyStylers.swift
+++ b/Stylish/PropertyStylers.swift
@@ -231,12 +231,12 @@ public extension Style {
 
 
 public extension Stylish {
-    public enum PropertyStylers {}
+    enum PropertyStylers {}
 }
 
 public extension Stylish.PropertyStylers {
     
-    public class UIView {
+    class UIView {
         
         public struct BackgroundColor: PropertyStyler {
             public static var propertyKey: String { return "backgroundColor" }
@@ -366,7 +366,7 @@ public extension Stylish.PropertyStylers {
         }
     }
     
-    public class UIControl: UIView {
+    class UIControl: UIView {
         
         public struct IsEnabled: PropertyStyler {
             public static var propertyKey: String { return "isEnabled" }
@@ -376,7 +376,7 @@ public extension Stylish.PropertyStylers {
         }
     }
     
-    public class StylishTextControl: UIControl {
+    class StylishTextControl: UIControl {
         
         public struct AdjustsFontSizeToFitWidth: PropertyStyler {
             public static var propertyKey: String { return "adjustsFontSizeToFitWidth" }
@@ -465,7 +465,7 @@ public extension Stylish.PropertyStylers {
         }
     }
     
-    public class UILabel: StylishTextControl {
+    class UILabel: StylishTextControl {
         
         public struct BaselineAdjustment: PropertyStyler {
             public static var propertyKey: String { return "baselineAdjustment" }
@@ -517,7 +517,7 @@ public extension Stylish.PropertyStylers {
         }
     }
     
-    public class StylishTextInputControl: StylishTextControl {
+    class StylishTextInputControl: StylishTextControl {
         
         public struct AllowsEditingTextAttributes: PropertyStyler {
             public static var propertyKey: String { return "allowsEditingTextAttributes" }
@@ -628,7 +628,7 @@ public extension Stylish.PropertyStylers {
         }
     }
     
-    public class UITextField: StylishTextInputControl {
+    class UITextField: StylishTextInputControl {
         
         public struct Background: PropertyStyler {
             public static var propertyKey: String { return "background" }
@@ -712,7 +712,7 @@ public extension Stylish.PropertyStylers {
         }
     }
     
-    public class UITextView: StylishTextInputControl {
+    class UITextView: StylishTextInputControl {
         
         public struct IsEditable: PropertyStyler {
             public static var propertyKey: String { return "isEditable" }
@@ -743,7 +743,7 @@ public extension Stylish.PropertyStylers {
         }
     }
     
-    public class UIButton: UIControl {
+    class UIButton: UIControl {
         
         public struct AdjustsImageWhenDisabled: PropertyStyler {
             public static var propertyKey: String { return "adjustsImageWhenDisabled" }
@@ -926,7 +926,7 @@ public extension Stylish.PropertyStylers {
         }
     }
     
-    public class UIImageView: UIView {
+    class UIImageView: UIView {
         
         public struct Image: PropertyStyler {
             public static var propertyKey: String { return "image" }

--- a/Stylish/Stylish.swift
+++ b/Stylish/Stylish.swift
@@ -66,7 +66,7 @@ public protocol PropertyStyler: AnyPropertyStylerType {
 }
 
 public extension PropertyStyler {
-    public static func set(value: PropertyType?) -> AnyPropertyStyler {
+    static func set(value: PropertyType?) -> AnyPropertyStyler {
         return AnyPropertyStyler {
             if let target = $0 as? TargetType {
                 Self.apply(value: value, to: target, using: $1)
@@ -74,7 +74,7 @@ public extension PropertyStyler {
         }
     }
     
-    public static func set(value: @escaping (Bundle, UITraitCollection?) -> PropertyType?) -> AnyPropertyStyler {
+    static func set(value: @escaping (Bundle, UITraitCollection?) -> PropertyType?) -> AnyPropertyStyler {
         return AnyPropertyStyler {
             if let target = $0 as? TargetType {
                 let value = value($1, (target as? UITraitEnvironment)?.traitCollection)
@@ -90,7 +90,7 @@ public protocol AnyPropertyStylerType {
 }
 
 public extension PropertyStyler  {
-    public static var wrapped: Any {
+    static var wrapped: Any {
         return AnyPropertyStylerTypeWrapper(Self.self)
     }
 }

--- a/StylishExample/StylishExample/stylesheet.json
+++ b/StylishExample/StylishExample/stylesheet.json
@@ -1,4 +1,7 @@
 {
+  "constants": {
+    "DefaultButtonColor": "#FDE3A7"
+  },
   "styles": [
     {
       "styleName": "PrimaryBackgroundColor",
@@ -38,7 +41,7 @@
       "styleName": "DefaultProgressBar",
       "styleProperties": {
         "progressColor": "#F27935",
-        "progressTrackColor": "#FDE3A7",
+        "progressTrackColor": "$DefaultButtonColor",
         "cornerRadiusRatio": 0.35,
         "progressCornerRadiusRatio": 0.35,
         "borderColor": "#F9690E",
@@ -67,8 +70,8 @@
       "styleName": "DefaultButton",
       "styleProperties": {
         "titleColorForNormalState": "#D35400",
-        "backgroundColor": "#FDE3A7",
-        "borderColor": "#FDE3A7",
+        "backgroundColor": "$DefaultButtonColor",
+        "borderColor": "$DefaultButtonColor",
         "cornerRadius": 6.0
       }
     }


### PR DESCRIPTION
- Migrated to Swift 5. Made StyleableComponents a public header
- Added support for constant values in the JSON file defined in a new object at the same level of the `styles` object
```
    "constants": {
        "PrimaryColor" : "#FF5A5F",
        "Header5Font" : {
            "name": "CircularStd-Bold",
            "size": 18.0
        }
    }
```

That can be later reused in the `styles` dictionary as following:
```
        {
            "styleName": "Primary",
            "styleProperties": {
                "backgroundColor": "$PrimaryColor"
            }
        },
        {
            "styleName": "Header5",
            "styleProperties": {
                "font": "$Header5Font",
                "textColor": "#3f444c"
            }
        }
```